### PR TITLE
Add support for HASH preprocessor variables

### DIFF
--- a/lib/IC.js
+++ b/lib/IC.js
@@ -387,6 +387,11 @@ module.exports = function () {
           }
         }
       } else {
+        // Pre-processor HASH function
+        if (token.match(/^HASH\("[^"]+"\)$/)) {
+          return undefined;
+        }
+
         // Float or integer from a define.
         if (fieldTypes.includes("f") || fieldTypes.includes("i")) {
           if (Object.keys(this._defines).includes(token)) {
@@ -839,6 +844,11 @@ module.exports = function () {
           return this._jumpTags[register];
         }
 
+        match = register.match(/^HASH\("([^"]+)"\)$/);
+        if (match) {
+          return this._crc32(match[1]) | 0;
+        }
+
         if (Object.keys(this._defines).includes(register)) {
           return this._defines[register];
         }
@@ -938,6 +948,19 @@ module.exports = function () {
           this._programCounter = Math.round(destination);
         }
       }
+    }
+  }, {
+    key: "_crc32",
+    value: function _crc32(r) {
+      for (var a, o = [], c = 0; c < 256; c++) {
+        a = c;
+        for (var f = 0; f < 8; f++) {
+          a = 1 & a ? 3988292384 ^ a >>> 1 : a >>> 1;
+        }o[c] = a;
+      }
+      for (var n = -1, t = 0; t < r.length; t++) {
+        n = n >>> 8 ^ o[255 & (n ^ r.charCodeAt(t))];
+      }return (-1 ^ n) >>> 0;
     }
   }]);
 

--- a/src/IC.js
+++ b/src/IC.js
@@ -280,6 +280,11 @@ module.exports = class IC {
         }
       }
     } else {
+      // Pre-processor HASH function
+      if (token.match(/^HASH\("[^"]+"\)$/)) {
+        return undefined;
+      }
+
       // Float or integer from a define.
       if (fieldTypes.includes("f") || fieldTypes.includes("i")) {
         if (Object.keys(this._defines).includes(token)) {
@@ -650,6 +655,11 @@ module.exports = class IC {
         return this._jumpTags[register];
       }
 
+      match = register.match(/^HASH\("([^"]+)"\)$/);
+      if (match) {
+        return this._crc32(match[1]) | 0;
+      }
+
       if (Object.keys(this._defines).includes(register)) {
         return this._defines[register];
       }
@@ -743,5 +753,17 @@ module.exports = class IC {
         this._programCounter = Math.round(destination);
       }      
     }
+  }
+
+  _crc32(r) {
+    for (var a, o = [], c = 0; c < 256; c++) {
+      a = c;
+      for (var f = 0; f < 8; f++)
+        a = 1 & a ? 3988292384 ^ a >>> 1 : a >>> 1;
+      o[c] = a;
+    }
+    for (var n = -1, t = 0; t < r.length; t++)
+      n = n >>> 8 ^ o[255 & (n ^ r.charCodeAt(t))];
+    return (-1 ^ n) >>> 0;
   }
 };

--- a/test/IC.test.js
+++ b/test/IC.test.js
@@ -1061,4 +1061,32 @@ describe("IC Tests", function () {
       expect(ic.getTokenisedInstructions()).to.deep.equal(expected);
     });
   });
+  
+  describe("Programs can use the HASH preprocessor which can be used throughout a program", function () {
+    it("should hash the value inside the IC and store provided value when run", function () {
+      let ic = new IC();
+
+      ic.load("define IRON HASH(\"ItemIronIngot\")");
+
+      expect(Object.keys(ic._defines)).to.contains("IRON");
+
+      ic.step();
+
+      expect(ic._defines["IRON"]).to.equal(-1301215609);
+    });
+
+    it("should substitute the hashed value when the define is used in a statement", function () {
+      let ic = new IC();
+
+      ic.load([
+        "define IRON HASH(\"ItemIronIngot\")",
+        "move r0 IRON"
+      ].join("\n"));
+
+      ic.step();      
+      expect(ic.step()).to.equal("END_OF_PROGRAM");
+
+      expect(ic.getInternalRegisters()[0]).to.equal(-1301215609);
+    });
+  });
 });


### PR DESCRIPTION
HASH preprocessor function takes the CRC32 (signed) of the value and stores it. This is a new feature added in the latest version of Stationeers.

https://store.steampowered.com/news/app/544550/view/3690179962073115356