### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,14 @@ var registerLabels = ourIC.getInternalLabels();
 ourIC.setInternalRegister(5, 9.999);
 ```
 
+### Interacting with the stack
+
+```
+// Retrieve a copy of the whole stack, array of floating point numbers.
+var stack = ourIC.getStack();
+// Setting the stack values is not supported.
+```
+
 ### Interacting with IO Registers
 
 ```

--- a/README.md
+++ b/README.md
@@ -117,15 +117,15 @@ ourIC.step();
 
 // Move the IC forward 128 instructions or until error/yield.
 var total = 0;
-var lastResult = this.step();
+var lastResult = ourIC.step();
 
 while(!lastResult && total < 128) {
-	total++;       
-	lastResult = this.step(); 
+	total++;
+	lastResult = ourIC.step();
 }
 ```
 
-`this.step()` will return an error if the program can not continue.
+`ourIC.step()` will return an error if the program can not continue.
 
 * YIELD - Yield instruction was run, halt until new power tick.
 * INVALID_REGISTER_LOCATION - Attempt to access a register which does not exist.


### PR DESCRIPTION
Fix a minor issue - `ourIC.step()` was referred to as `this.step()` in a few places
Add documentation about getting the stack